### PR TITLE
Filter empty strings from pathInfo

### DIFF
--- a/example/src/Site.hs
+++ b/example/src/Site.hs
@@ -99,7 +99,7 @@ site ctxt =
              ,path "param_many" /? paramMany "id" ==> paramManyHandler
              ,path "template" ==> templateHandler
              ,path "db" /? param "number" ==> dbHandler
-             ,path "segment" // segment ==> segmentHandler
+             ,path "segment" // segment // end ==> segmentHandler
              ,path "redis" // segment /? paramOpt "set" ==> redisHandler
              ,path "session" ==> sessionHandler
              ,path "file" ==> fileHandler

--- a/example/test/Spec.hs
+++ b/example/test/Spec.hs
@@ -20,6 +20,12 @@ main = do
        describe "GET /segment/foo" $
          it "responds with foo" $
            get "/segment/foo" `shouldRespondWith` "foo"
+       describe "GET /segment/foo/" $
+         it "also responds with foo (trailing slash doesn't matter)" $
+           get "/segment/foo/" `shouldRespondWith` "foo"
+       describe "GET /segment//foo" $
+         it "STILL responds with foo (extra slash doesn't matter)" $
+           get "/segment//foo" `shouldRespondWith` "foo"
        describe "GET /random/path" $
          it "should 404" $
            get "/random/path" `shouldRespondWith` 404

--- a/fn/src/Web/Fn.hs
+++ b/fn/src/Web/Fn.hs
@@ -143,7 +143,7 @@ route :: RequestContext ctxt =>
 route ctxt pths =
   do let (r,post) = getRequest ctxt
          m = either (const GET) id (parseMethod (requestMethod r))
-         req = (pathInfo r, queryString r, m, post)
+         req = (filter (/= "") (pathInfo r), queryString r, m, post)
      route' req pths
   where route' _ [] = return Nothing
         route' req (x:xs) =


### PR DESCRIPTION
Fixes the bug that "localhost/path" and "localhost/path/" don't match the same route.
