### PR TITLE
Better file handling

### DIFF
--- a/fn-extra/src/Web/Fn/Extra/Digestive.hs
+++ b/fn-extra/src/Web/Fn/Extra/Digestive.hs
@@ -39,31 +39,20 @@ requestFormEnv req = do
      case v of
        Nothing -> liftIO $ parseRequestBody (tempFileBackEnd' st)
                                             (fst req)
-       Just (q,_) -> return (q,[])
+       Just (q,_) -> return q
   return $ queryFormEnv ((map (second Just) query) ++ queryString (fst req)) files
-
-tempFileBackEnd' :: InternalState -> ignored1 -> FileInfo () -> IO ByteString -> IO FilePath
-tempFileBackEnd' is x fi@(FileInfo nm _ _) = tempFileBackEndOpts getTemporaryDirectory (T.unpack $ T.decodeUtf8 nm) is x fi
 
 -- | This function runs a form and passes the function in it's last
 -- argument the result, which is a 'View' and an optional result. If
 -- the request is a get, or if the form failed to validate, the result
 -- will be 'Nothing' and you should render the form (with the errors
 -- from the 'View').
---
--- WARNING: If you have already parsed the request body with '!=>'
--- (even if the route didn't end up matching), this will _only_ get
--- post parameters, it will not see any files that were posted. This
--- is a current implementation limitation that will (hopefully) be
--- resolved eventually, but for now, it is safest to just never use
--- '!=>' if you are using digestive functors (as the expectation is
--- that it will be handling all your POST needs!).
 runForm :: RequestContext ctxt =>
-        ctxt
-     -> Text
-     -> Form v IO a
-     -> ((View v, Maybe a) -> IO a1)
-     -> IO a1
+       ctxt
+    -> Text
+    -> Form v IO a
+    -> ((View v, Maybe a) -> IO a1)
+    -> IO a1
 runForm ctxt nm frm k =
   runResourceT $ let r = fst (getRequest ctxt) in
     if requestMethod r == methodPost

--- a/fn/fn.cabal
+++ b/fn/fn.cabal
@@ -92,6 +92,7 @@ library
                      , unordered-containers
                      , filepath
                      , directory
+                     , resourcet
   default-language:    Haskell2010
   ghc-options:         -Wall
 
@@ -109,6 +110,7 @@ test-suite fn-test
                      , unordered-containers
                      , filepath
                      , directory
+                     , resourcet
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/fn/test/Spec.hs
+++ b/fn/test/Spec.hs
@@ -26,17 +26,17 @@ instance RequestContext R where
 rr :: R
 rr = R ([], [])
 p :: [Text] -> Req
-p y = (y,[],GET,Just emv)
+p y = (defaultRequest,y,[],GET,Just emv)
 _p :: [Text] -> Req ->  Req
-_p y (_,q',m',x') = (y,q',m',x')
+_p y (r,_,q',m',x') = (r,y,q',m',x')
 q :: Query -> Req
-q y = ([],y,GET,Just emv)
+q y = (defaultRequest,[],y,GET,Just emv)
 _q :: Query -> Req -> Req
-_q y (p',_,m',x') = (p',y,m',x')
+_q y (r,p',_,m',x') = (r,p',y,m',x')
 m :: StdMethod -> Req
-m y = ([],[],y,Just emv)
+m y = (defaultRequest,[],[],y,Just emv)
 _m :: StdMethod -> Req -> Req
-_m y (p',q',_,x') = (p',q',y,x')
+_m y (r,p',q',_,x') = (r,p',q',y,x')
 
 
 j :: Show a => IO (Maybe (a,b)) -> Expectation


### PR DESCRIPTION
This does a few things:
1. Parses request body automatically with route matchers `file` and `files`. If you are using those, you definitely want `Fn` to parse the body, so there is no reason we should require '!=>`. 
2. Stores uploaded files as temporary files, rather than in memory bytestrings. This makes it compatible with digestive-functors, which will close #7. The files themselves are cleaned up when the request finishes.
