### PR TITLE
Add MINIMAL pragma to RequestContext class

### DIFF
--- a/fn/CHANGELOG.md
+++ b/fn/CHANGELOG.md
@@ -1,3 +1,7 @@
+* 0.3.1.1 Tom Murphy <tom@tinybop.com> 2018-10-12
+
+  - Add MINIMAL pragma for RequestContext class
+
 * 0.3.1 Libby Horacek <libby@positiondev.com> 2017-6-13
 
   - Update base dependencies to support GHC 8.4

--- a/fn/fn.cabal
+++ b/fn/fn.cabal
@@ -1,5 +1,5 @@
 name:                fn
-version:             0.3.1
+version:             0.3.1.1
 synopsis:            A functional web framework.
 description:
   A Haskell web framework where you write plain old functions.

--- a/fn/src/Web/Fn.hs
+++ b/fn/src/Web/Fn.hs
@@ -135,6 +135,7 @@ class RequestContext ctxt where
   setRequest c r =
     let (Store _ b) = requestLens (`Store` id) c
     in b r
+  {-# MINIMAL requestLens | (getRequest, setRequest) #-}
 
 instance RequestContext FnRequest where
   getRequest = id


### PR DESCRIPTION
This way if someone writes an instance of `RequestContext` with no non-default methods like:

```haskell
instance RequestContext Foo where
```

They'll get a warning like:

```
foo.hs:6:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        either ‘requestLens’ or (‘getRequest’ and ‘setRequest’)
    • In the instance declaration for ‘RequestContext Foo’
```