### PR TITLE
Don't throw an error if a param contains a non-unicode character

### DIFF
--- a/fn/CHANGELOG.md
+++ b/fn/CHANGELOG.md
@@ -1,3 +1,11 @@
+* 0.4.0 Libby Horacek <libby@positiondev.com> 2019-4-18
+
+  - To get `Text` param values, we have to convert from `Bytestring`. If
+    the Bytestring isn't a valid Unicode character, `decodeUtf8` throws an
+    exception. Replaced `decodeUtf8` with `decodeUtf8With lenientDecode`, which
+    will instead replace the invalid character with the Unicode replacement
+    character U+FFFD.
+
 * 0.3.1.1 Tom Murphy <tom@tinybop.com> 2018-10-12
 
   - Add MINIMAL pragma for RequestContext class

--- a/fn/test/Spec.hs
+++ b/fn/test/Spec.hs
@@ -105,6 +105,8 @@ main = hspec $ do
     it "should match query parameters with param" $
       do v (param "foo" (q [("foo", Nothing)])) (t1 "")
          vn (param "foo" (q [])) t1u
+    it "should map invalid bytestring param values to Unicode replacement character" $
+         v (param "foo" (q [("foo", Just "bar\xc3")])) (t1 "bar\65533")
     it "should match combined param and paths with /?" $
       do v ((path "a" /? param "id") (_p ["a"] $ q [("id", Just "x")])) (t1 "x")
          vn ((path "a" /? param "id") (_p ["b"] $ q [("id", Just "x")])) t1u


### PR DESCRIPTION
Fixes #23 